### PR TITLE
Fix Kanban imports and entry path

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,6 +9,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+  <script type="module" src="/src/app/main.tsx"></script>
   </body>
 </html>

--- a/frontend/src/features/kanban/KanbanPage.tsx
+++ b/frontend/src/features/kanban/KanbanPage.tsx
@@ -1,6 +1,6 @@
 // modules/tasks/KanbanPage.tsx
 import React, { useState } from "react"
-import { useKanbanStore, Status } from "@/store/useKanbanStore"
+import { useKanbanStore, Status } from "@/store/kanbanSlice"
 
 const STATUSES: Status[] = ["pendiente", "progreso", "hecho"]
 const statusLabels: Record<Status, string> = {

--- a/frontend/src/store/kanbanSlice.ts
+++ b/frontend/src/store/kanbanSlice.ts
@@ -1,54 +1,37 @@
 import { create } from "zustand";
 
-type Status = "pendiente" | "haciendo" | "terminado";
+export type Status = "pendiente" | "progreso" | "hecho";
 
-interface KanbanCard {
+export interface Task {
   id: string;
   title: string;
-  content?: string;
+  status: Status;
 }
 
 interface KanbanState {
-  columns: Record<Status, KanbanCard[]>;
-  addCard: (status: Status, card: KanbanCard) => void;
-  moveCard: (from: Status, to: Status, cardId: string) => void;
-  removeCard: (status: Status, cardId: string) => void;
+  tasks: Task[];
+  addTask: (title: string, status: Status) => void;
+  moveTask: (id: string, status: Status) => void;
+  removeTask: (id: string) => void;
 }
 
 export const useKanbanStore = create<KanbanState>((set) => ({
-  columns: {
-    pendiente: [],
-    haciendo: [],
-    terminado: [],
-  },
-
-  addCard: (status, card) =>
+  tasks: [],
+  addTask: (title, status) =>
     set((state) => ({
-      columns: {
-        ...state.columns,
-        [status]: [...state.columns[status], card],
-      },
+      tasks: [
+        ...state.tasks,
+        { id: Date.now().toString(), title, status },
+      ],
     })),
-
-  moveCard: (from, to, cardId) =>
-    set((state) => {
-      const card = state.columns[from].find((c) => c.id === cardId);
-      if (!card) return state;
-
-      return {
-        columns: {
-          ...state.columns,
-          [from]: state.columns[from].filter((c) => c.id !== cardId),
-          [to]: [...state.columns[to], card],
-        },
-      };
-    }),
-
-  removeCard: (status, cardId) =>
+  moveTask: (id, status) =>
     set((state) => ({
-      columns: {
-        ...state.columns,
-        [status]: state.columns[status].filter((c) => c.id !== cardId),
-      },
+      tasks: state.tasks.map((t) =>
+        t.id === id ? { ...t, status } : t
+      ),
+    })),
+  removeTask: (id) =>
+    set((state) => ({
+      tasks: state.tasks.filter((t) => t.id !== id),
     })),
 }));


### PR DESCRIPTION
## Summary
- fix entry path in `index.html`
- update Kanban store to match component usage
- fix Kanban page import

## Testing
- `npm run lint` *(fails: couldn't find ESLint config)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6856e7ce17ac8329a8f9273401a8695e